### PR TITLE
add KSP-AVC version file for auto-module checking

### DIFF
--- a/Output/GameData/RealChute/RealChute.version
+++ b/Output/GameData/RealChute/RealChute.version
@@ -1,0 +1,14 @@
+{
+  "NAME": "RealChute",
+  "URL": "https://raw.githubusercontent.com/StupidChris/RealChute/master/Output/GameData/RealChute/RealChute.version",
+  "VERSION": {
+    "MAJOR": 1,
+    "MINOR": 0,
+    "PATCH": "RC2"
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
+  }
+}


### PR DESCRIPTION
Dearest stupid_chris,

I just started working with @tyrope on a project to add a version checker to KSP modules. I know that it would help me a lot! He said that helping him contact module authors would be really helpful so here I am! If you would be willing to accept this patch we would really appreciate it!

The KSP Addon Version Checker is my attempt at trying to have some sort of version checking available for people who play KSP with lots of mods. more information and source available [right here on github](https://github.com/tyrope/KSP-addon-version-checker)

**Note**: I think I got this in the right place. It needs to live somewhere online and also somewhere in the GameData folder for users. 

PS. Since you're a mod on the forum I would particularly like to hear your feedback on the mod. We tried to make it very general so someone like blizzy could use these version files to implement version checking. We have a python script but I don't envision that most people will be able to run python immediately. Do you think this will help out the community at large?
