### PR TITLE
Fixed up .version file a bit. Removed some extra quotes that were breaki...

### DIFF
--- a/Output/GameData/RealChute/RealChute.version
+++ b/Output/GameData/RealChute/RealChute.version
@@ -4,11 +4,17 @@
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 2,
-    "PATCH": "2"
+    "PATCH": 2,
+    "BUILD": 2
   },
-  "KSP_VERSION": {
+  "KSP_VERSION_MIN": {
     "MAJOR": 0,
     "MINOR": 24,
     "PATCH": 0
+  },
+  "KSP_VERSION_MAX": {
+    "MAJOR": 0,
+    "MINOR": 24,
+    "PATCH": 1
   }
 }


### PR DESCRIPTION
...ng KSP-AVC's version parsing so it showed a zeroed version number. Added a build entry for the version number (currently 1.2.2.2), and marked that it works with 0.24.0 to 0.24.1.

Obviously, set these values as you see fit. The important part was the quotes that needed removal, but I thought the changes I put into mine would suit you. You can always talk to me on IRC about it (it's Addle).
