### PR TITLE
Stopping the timewarp upon deployment

### DIFF
--- a/RealChute/RealChuteModule.cs
+++ b/RealChute/RealChuteModule.cs
@@ -261,6 +261,9 @@ namespace RealChute
         //Activates the parachute
         public void ActivateRC()
         {
+            // Stop the timewarp instantly
+            TimeWarp.SetRate(0, true);
+            
             this.staged = true;
             if (settings.autoArm) { this.armed = true; }
             Events["GUIDeploy"].active = false;


### PR DESCRIPTION
The long deployment is awesome to avoid G spikes: however, the deployment seems to happen in real time discarding the timewarp time step.
I suggest to stop the timewarp when the parachute deploys, for added safety.
