### PR TITLE
Make chute arm/deploy at correct stage.

### DIFF
--- a/RealChute/RealChuteModule.cs
+++ b/RealChute/RealChuteModule.cs
@@ -452,7 +452,7 @@ namespace RealChute
             Vector3 velocity = this.part.Rigidbody.velocity + Krakensbane.GetFrameVelocityV3f();
             sqrSpeed = velocity.sqrMagnitude;
             dragVector = -velocity.normalized;
-            if (!this.staged && GameSettings.LAUNCH_STAGES.GetKeyDown() && this.vessel.isActiveVessel && this.part.inverseStage == Staging.CurrentStage - 1) { ActivateRC(); }
+            if (!this.staged && GameSettings.LAUNCH_STAGES.GetKeyDown() && this.vessel.isActiveVessel && (this.part.inverseStage == Staging.CurrentStage - 1 || Staging.CurrentStage == 0)) { ActivateRC(); }
             if (this.deployOnGround && !this.staged)
             {
                 if (!this.launched && !this.vessel.LandedOrSplashed)


### PR DESCRIPTION
On my machine at least when staging happens the current stage is the stage which we are coming from not the stage we are going to so the part stage needs to be compared to CurrentStage - 1 (next stage).

Previously this was working because the code for OnActive() would call ActivateRC().  With OnActive() removed though this has to work.
