### PR TITLE
Add missing commas to version file

### DIFF
--- a/Output/GameData/RealChute/RealChute.version
+++ b/Output/GameData/RealChute/RealChute.version
@@ -15,14 +15,14 @@
 		"MAJOR": 1,
 		"MINOR": 1,
 		"PATCH": 2
-	}
+	},
 
 	"KSP_VERSION_MIN":
 	{
 		"MAJOR": 1,
 		"MINOR": 1,
 		"PATCH": 2
-	}
+	},
 
 	"KSP_VERSION_MAX":
 	{


### PR DESCRIPTION
The .version file's syntax errors are preventing CKAN's indexer from picking up the release. I manually PRed RealChute-v1.4.1.1 into CKAN with the compatibility specified in the .version file. The next release will be picked up as expected/as usual.