### PR TITLE
Fix up the MM patches a bit

### DIFF
--- a/Output/GameData/RealChute/Patches/RC_StockPatches.cfg
+++ b/Output/GameData/RealChute/Patches/RC_StockPatches.cfg
@@ -1,4 +1,4 @@
-@PART[parachuteDrogue]:FOR[RealChute]:NEEDS[!ReStock]
+@PART[parachuteDrogue]:NEEDS[RealChute,!ReStock]
 {
 	
 	maximum_drag = 0.32
@@ -93,7 +93,7 @@
 	}
 }
 
-@PART[parachuteLarge]:FOR[RealChute]:NEEDS[!ReStock]
+@PART[parachuteLarge]:NEEDS[RealChute,!ReStock]
 {
 
 	maximum_drag = 0.32
@@ -188,7 +188,7 @@
 	}
 }
 
-@PART[parachuteSingle]:FOR[RealChute]:NEEDS[!ReStock]
+@PART[parachuteSingle]:NEEDS[RealChute,!ReStock]
 {
 
 	maximum_drag = 0.32
@@ -283,7 +283,7 @@
 	}
 }
 
-@PART[parachuteRadial]:FOR[RealChute]:NEEDS[!ReStock]
+@PART[parachuteRadial]:NEEDS[RealChute,!ReStock]
 {
 
 	maximum_drag = 0.32
@@ -378,7 +378,7 @@
 	}
 }
 
-@PART[radialDrogue]:FOR[RealChute]:NEEDS[!ReStock]
+@PART[radialDrogue]:NEEDS[RealChute,!ReStock]
 {
 	
 	maximum_drag = 0.32

--- a/Output/GameData/RealChute/Patches/RC_StockPatches.cfg
+++ b/Output/GameData/RealChute/Patches/RC_StockPatches.cfg
@@ -1,4 +1,4 @@
-@PART[parachuteDrogue]:FOR[RealChute]:NEEDS[RealChute,!ReStock]
+@PART[parachuteDrogue]:FOR[RealChute]:NEEDS[!ReStock]
 {
 	
 	maximum_drag = 0.32
@@ -93,7 +93,7 @@
 	}
 }
 
-@PART[parachuteLarge]:FOR[RealChute]:NEEDS[RealChute,!ReStock]
+@PART[parachuteLarge]:FOR[RealChute]:NEEDS[!ReStock]
 {
 
 	maximum_drag = 0.32
@@ -188,7 +188,7 @@
 	}
 }
 
-@PART[parachuteSingle]:FOR[RealChute]:NEEDS[RealChute,!ReStock]
+@PART[parachuteSingle]:FOR[RealChute]:NEEDS[!ReStock]
 {
 
 	maximum_drag = 0.32
@@ -283,7 +283,7 @@
 	}
 }
 
-@PART[parachuteRadial]:FOR[RealChute]:NEEDS[RealChute,!ReStock]
+@PART[parachuteRadial]:FOR[RealChute]:NEEDS[!ReStock]
 {
 
 	maximum_drag = 0.32
@@ -378,7 +378,7 @@
 	}
 }
 
-@PART[radialDrogue]:FOR[RealChute]:NEEDS[RealChute,!ReStock]
+@PART[radialDrogue]:FOR[RealChute]:NEEDS[!ReStock]
 {
 	
 	maximum_drag = 0.32

--- a/Output/GameData/RealChute/Patches/RC_StockTextureLibrary.cfg
+++ b/Output/GameData/RealChute/Patches/RC_StockTextureLibrary.cfg
@@ -1,4 +1,4 @@
-TEXTURE_LIBRARY
+TEXTURE_LIBRARY:NEEDS[RealChute]
 {
 	name = StockReplacement
 

--- a/Output/GameData/RealChute/Patches/RC_VABOPatches.cfg
+++ b/Output/GameData/RealChute/Patches/RC_VABOPatches.cfg
@@ -1,4 +1,4 @@
-@PART[parachuteDrogue]:AFTER[VABOrganizer]
+@PART[parachuteDrogue]:NEEDS[RealChute]:AFTER[VABOrganizer]
 {
 	@VABORGANIZER
 	{

--- a/Output/GameData/RealChute/Patches/RC_VABOPatches.cfg
+++ b/Output/GameData/RealChute/Patches/RC_VABOPatches.cfg
@@ -6,7 +6,7 @@
 	}
 }
 
-@PART[parachuteLarge]:AFTER[VABOrganizer]
+@PART[parachuteLarge]:NEEDS[RealChute]:AFTER[VABOrganizer]
 {
 	@VABORGANIZER
 	{
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[parachuteSingle]:AFTER[VABOrganizer]
+@PART[parachuteSingle]:NEEDS[RealChute]:AFTER[VABOrganizer]
 {
 	@VABORGANIZER
 	{
@@ -22,7 +22,7 @@
 	}
 }
 
-@PART[parachuteRadial]:AFTER[VABOrganizer]
+@PART[parachuteRadial]:NEEDS[RealChute]:AFTER[VABOrganizer]
 {
 	@VABORGANIZER
 	{
@@ -30,7 +30,7 @@
 	}
 }
 
-@PART[radialDrogue]:AFTER[VABOrganizer]
+@PART[radialDrogue]:NEEDS[RealChute]:AFTER[VABOrganizer]
 {
 	@VABORGANIZER
 	{


### PR DESCRIPTION
Everything in the Patches folder is only installed through the `RealChuteForStock` mod (when using CKAN), so anything in this folder should have a NEEDS on RealChute. (although CKAN handles dependencies anyway, its good to be safe)

Also, RC_StockPatches was using incorrect behavior, as declaring a FOR[RealChute] will tell MM that RealChute is already installed.